### PR TITLE
Fix: Scope anchor transition to color

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -404,7 +404,7 @@ button,
 a {
   text-decoration: none;
   color: #eb5286;
-  transition: .25s all ease-out;
+  transition: .25s color ease-out;
 }
 
 a:hover {


### PR DESCRIPTION
Stops any unwanted animations, example of the bug:
![skeleventy-anchor-animation](https://user-images.githubusercontent.com/1177460/52743879-f1ed2900-2fd2-11e9-81fa-9a808f39c4df.gif)
